### PR TITLE
Improve BAMO pack loading/discovery

### DIFF
--- a/BAMO.js
+++ b/BAMO.js
@@ -556,7 +556,7 @@
                 }
 
                 // Define folder locations
-                var dataFolder = settings.minecraftFolder.value + "\\bamo\\data\\";
+                var dataFolder = settings.minecraftFolder.value + "\\bamo\\objects\\";
                 var blockstatesFolder = settings.minecraftFolder.value + "\\bamo\\assets\\" + this.properties.namespace + "\\blockstates\\";
                 var blockModelsFolder = settings.minecraftFolder.value + "\\bamo\\assets\\" + this.properties.namespace + "\\models\\block\\";
                 var itemModelsFolder = settings.minecraftFolder.value + "\\bamo\\assets\\" + this.properties.namespace + "\\models\\item\\";

--- a/BAMO/src/main/kotlin/com/ryytikki/bamo/Bamo.kt
+++ b/BAMO/src/main/kotlin/com/ryytikki/bamo/Bamo.kt
@@ -1,14 +1,19 @@
 package com.ryytikki.bamo
 
+import com.ryytikki.bamo.tools.BamoPackFinder
 import com.ryytikki.bamo.tools.BlockGenerator
+import net.minecraftforge.api.distmarker.Dist
+import net.minecraftforge.fml.DistExecutor
+import net.minecraftforge.fml.DistExecutor.SafeRunnable
 import net.minecraftforge.fml.common.Mod
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent
-import net.minecraftforge.fml.event.server.FMLServerAboutToStartEvent
+import net.minecraftforge.fml.event.server.FMLServerStartingEvent
 import org.apache.logging.log4j.Level
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import thedarkcolour.kotlinforforge.forge.FORGE_BUS
 import thedarkcolour.kotlinforforge.forge.MOD_BUS
+
 
 /**
  * Main mod class. Should be an `object` declaration annotated with `@Mod`.
@@ -34,8 +39,10 @@ object Bamo {
 
         // usage of the KotlinEventBus
         MOD_BUS.addListener(::onClientSetup)
-        FORGE_BUS.addListener(::onServerAboutToStart)
+        FORGE_BUS.addListener(::onServerStarting)
 
+        // Add our resource pack finder (FMLClientSetupEvent is too late to do this)
+        DistExecutor.safeRunWhenOn(Dist.CLIENT) { SafeRunnable { BamoPackFinder.addToResourcePacks() } }
     }
 
     /**
@@ -51,7 +58,7 @@ object Bamo {
     /**
      * Fired on the global Forge bus.
      */
-    private fun onServerAboutToStart(event: FMLServerAboutToStartEvent) {
-        LOGGER.log(Level.INFO, "Server starting...")
+    private fun onServerStarting(event: FMLServerStartingEvent) {
+        BamoPackFinder.addToDataPacks(event.server)
     }
 }

--- a/BAMO/src/main/kotlin/com/ryytikki/bamo/tools/BamoPackFinder.kt
+++ b/BAMO/src/main/kotlin/com/ryytikki/bamo/tools/BamoPackFinder.kt
@@ -1,0 +1,54 @@
+package com.ryytikki.bamo.tools
+
+import com.ryytikki.bamo.Bamo
+import com.ryytikki.bamo.Bamo.LOGGER
+import net.minecraft.client.Minecraft
+import net.minecraft.resources.*
+import net.minecraft.resources.IPackNameDecorator.DEFAULT
+import net.minecraft.resources.ResourcePackInfo.IFactory
+import net.minecraft.resources.ResourcePackInfo.Priority.TOP
+import net.minecraft.server.MinecraftServer
+import net.minecraftforge.fml.loading.FMLPaths
+import java.io.File
+import java.io.FileFilter
+import java.util.function.Consumer
+
+object BamoPackFinder : IPackFinder {
+    private val PACKS_DIR = File(FMLPaths.GAMEDIR.get().toString() + "/bamopacks")
+    private val PACK_FILTER = FileFilter { file ->
+        val isZip = file.isFile && file.name.endsWith(".zip")
+        val isDir = file.isDirectory && File(file, "pack.mcmeta").isFile
+        isZip || isDir
+    }
+
+    override fun loadPacks(packInfos: Consumer<ResourcePackInfo>, infoFactory: IFactory) =
+        findPacks().forEach { (name, file) ->
+            // Largely copied over from FolderPackFinder, with some adjustments
+            // TODO: Compile all packs into one info object, like Forge does for mods?
+            val packSupplier: () -> IResourcePack = { if (file.isDirectory) FolderPack(file) else FilePack(file) }
+            val packInfo = ResourcePackInfo.create(name, true, packSupplier, infoFactory, TOP, DEFAULT)
+            if (packInfo != null) packInfos.accept(packInfo)
+        }
+
+    /** Finds and compiles all BAMO packs into a map */
+    fun findPacks(): Map<String, File> {
+        val packs = HashMap<String, File>()
+        if (PACKS_DIR.isDirectory || PACKS_DIR.mkdir()) {
+            PACKS_DIR.listFiles(PACK_FILTER)?.forEach { packs["${Bamo.ID}:${it.name}"] = it }
+        } else LOGGER.error("Failed to find or create bamopacks directory")
+        return packs
+    }
+
+    // TODO: Forge added a better way to do this in 1.17+ via AddPackFindersEvent
+    /** Adds this pack finder to the server pack repo */
+    fun addToDataPacks(server: MinecraftServer) {
+        val packRepo = server.packRepository
+        packRepo.addPackFinder(BamoPackFinder)
+        packRepo.reload()
+        server.reloadResources(packRepo.selectedIds).get()
+    }
+
+    // TODO: Forge added a better way to do this in 1.17+ via AddPackFindersEvent
+    /** Adds this pack finder to the client pack repo */
+    fun addToResourcePacks() = Minecraft.getInstance().resourcePackRepository.addPackFinder(BamoPackFinder)
+}

--- a/BAMO/src/main/kotlin/com/ryytikki/bamo/tools/BlockGenerator.kt
+++ b/BAMO/src/main/kotlin/com/ryytikki/bamo/tools/BlockGenerator.kt
@@ -169,7 +169,8 @@ val tabsMap = mapOf<String, ItemGroup>(
 
 // Get list of JSON files in the bamoFiles folder
 fun getJSONPaths() : MutableList<String>{
-    val JSONPaths = Paths.get(FMLPaths.GAMEDIR.get().toString(), "/resourcepacks/bamo/data")
+    // TODO: Load multiple packs, maybe use BamoPackFinder#findPacks
+    val JSONPaths = Paths.get(FMLPaths.GAMEDIR.get().toString(), "/bamopacks/bamo/objects")
     if (Files.exists((JSONPaths))) {
         val paths: MutableList<String> = ArrayList()
         Files.walk(JSONPaths).filter { item -> Files.isRegularFile(item) }


### PR DESCRIPTION
As a side effect, changes the BAMO data directory to "objects" since "data" is reserved for regular Minecraft data packs.

I also haven't tested the exporter; I just changed a variable so hopefully it works without issue.