### PR TITLE
Pack Finders Update

### DIFF
--- a/BAMO_BSMP/build.gradle
+++ b/BAMO_BSMP/build.gradle
@@ -12,6 +12,10 @@ archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
 
+loom {
+    accessWidenerPath = file("src/main/resources/bamo.accesswidener")
+}
+
 repositories {
     // Add repositories to retrieve artifacts from in here.
 	// You should only use this when depending on other mods because

--- a/BAMO_BSMP/src/main/kotlin/com/ryytikki/bamo/tools/BamoDataPackFinder.kt
+++ b/BAMO_BSMP/src/main/kotlin/com/ryytikki/bamo/tools/BamoDataPackFinder.kt
@@ -1,21 +1,16 @@
 package com.ryytikki.bamo.tools
 
-import com.mojang.bridge.game.PackType
 import com.ryytikki.bamo.ID
 import com.ryytikki.bamo.LOGGER
 import net.fabricmc.api.EnvType
-import net.fabricmc.fabric.mixin.resource.loader.ResourcePackManagerAccessor
 import net.fabricmc.loader.api.FabricLoader
-import net.minecraft.SharedConstants
-import net.minecraft.client.MinecraftClient
-import net.minecraft.resource.ZipResourcePack
 import net.minecraft.resource.DirectoryResourcePack
-import net.minecraft.resource.ResourcePackProvider
-import net.minecraft.resource.ResourcePackSource.PACK_SOURCE_NONE
 import net.minecraft.resource.ResourcePackProfile
-import net.minecraft.resource.ResourcePackProfile.Factory
 import net.minecraft.resource.ResourcePackProfile.InsertionPosition.TOP
-import net.minecraft.resource.metadata.PackResourceMetadata
+import net.minecraft.resource.ResourcePackProvider
+import net.minecraft.resource.ResourcePackSource.NONE
+import net.minecraft.resource.ResourceType
+import net.minecraft.resource.ZipResourcePack
 import net.minecraft.server.MinecraftServer
 import net.minecraft.text.Text
 import java.io.File
@@ -39,11 +34,11 @@ object BamoDataPackFinder : ResourcePackProvider {
         }
     }
 
-    override fun register(infoConsumer: Consumer<ResourcePackProfile>, infoFactory: Factory) {
+    override fun register(infoConsumer: Consumer<ResourcePackProfile>) {
         // Create the pack info objects for each BAMO pack
         val compiledInfo = packFiles.mapNotNull { (name, file) ->
-            val packSupplier = { if (file.isDirectory) DirectoryResourcePack(file) else ZipResourcePack(file) }
-            ResourcePackProfile.of(name, true, packSupplier, infoFactory, TOP, PACK_SOURCE_NONE)
+            val packSupplier = { _: String -> if (file.isDirectory) DirectoryResourcePack(name, file.toPath(), false) else ZipResourcePack(name, file, false) }
+            ResourcePackProfile.create(name, Text.literal(name), true, packSupplier, ResourceType.SERVER_DATA, TOP, NONE)
         }
         // Return the unmerged list to enable tag support
         return compiledInfo.forEach(infoConsumer::accept)
@@ -52,7 +47,7 @@ object BamoDataPackFinder : ResourcePackProvider {
     /** Adds this pack finder to the server pack repo */
     fun addToDataPacks(server: MinecraftServer) {
         val packRepo = server.dataPackManager
-        (packRepo as ResourcePackManagerAccessor).providers.add(BamoDataPackFinder)
+        packRepo.providers.add(BamoDataPackFinder)
         packRepo.scanPacks()
         server.reloadResources(packRepo.enabledNames).get()
     }

--- a/BAMO_BSMP/src/main/kotlin/com/ryytikki/bamo/tools/MergedResourcePack.kt
+++ b/BAMO_BSMP/src/main/kotlin/com/ryytikki/bamo/tools/MergedResourcePack.kt
@@ -1,9 +1,6 @@
 package com.ryytikki.bamo.tools
 
-import net.minecraft.resource.AbstractFileResourcePack
-import net.minecraft.resource.ResourceNotFoundException
-import net.minecraft.resource.ResourcePack
-import net.minecraft.resource.ResourceType
+import net.minecraft.resource.*
 import net.minecraft.resource.ResourceType.CLIENT_RESOURCES
 import net.minecraft.resource.ResourceType.SERVER_DATA
 import net.minecraft.resource.metadata.PackResourceMetadata
@@ -11,14 +8,13 @@ import net.minecraft.resource.metadata.ResourceMetadataReader
 import net.minecraft.util.Identifier
 import java.io.File
 import java.io.InputStream
-import java.util.function.Predicate
 
 class MergedResourcePack(
     id: String,
     private val packName: String,
     private val packInfo: PackResourceMetadata,
     private val combinedPacks: List<ResourcePack>
-) : AbstractFileResourcePack(File(id)) {
+) : AbstractFileResourcePack(id, false) {
     private val resourcePacks = separatePacks(combinedPacks, CLIENT_RESOURCES)
     private val dataPacks = separatePacks(combinedPacks, SERVER_DATA)
 
@@ -47,39 +43,26 @@ class MergedResourcePack(
         if (deserializer.key.equals("pack")) packInfo as T else null
 
     override fun findResources(
-        type: ResourceType,
-        namespace: String,
-        path: String,
-        maxDepth: Int,
-        filter: Predicate<String>
-    ) = combinedPacks.flatMap { it.findResources(type, namespace, path, maxDepth, filter) }
+        type: ResourceType?,
+        namespace: String?,
+        prefix: String?,
+        consumer: ResourcePack.ResultConsumer?
+    ) = combinedPacks.forEach { it.findResources(type, namespace, prefix, consumer) }
 
     override fun getNamespaces(type: ResourceType) =
         if (type === CLIENT_RESOURCES) resourcePacks.keys else dataPacks.keys
 
     override fun close() = combinedPacks.forEach(ResourcePack::close)
 
-    override fun openRoot(fileName: String) = throw ResourceNotFoundException(base, fileName)
+    override fun openRoot(vararg segments: String?): InputSupplier<InputStream>? = null
 
-    override fun openFile(resourcePath: String) = throw ResourceNotFoundException(base, resourcePath)
-
-    override fun containsFile(resourcePath: String) = false
-
-    override fun open(type: ResourceType, location: Identifier): InputStream {
+    override fun open(type: ResourceType, location: Identifier): InputSupplier<InputStream>? {
         for (pack in getPacks(type, location)) {
-            if (pack.contains(type, location)) {
-                return pack.open(type, location)
+            val stream = pack.open(type, location)
+            if (stream != null) {
+                return stream
             }
         }
-        throw ResourceNotFoundException(base, "${type.directory}/${location.namespace}/${location.path}")
-    }
-
-    override fun contains(type: ResourceType, location: Identifier): Boolean {
-        for (pack in getPacks(type, location)) {
-            if (pack.contains(type, location)) {
-                return true
-            }
-        }
-        return false
+        return null
     }
 }

--- a/BAMO_BSMP/src/main/resources/bamo.accesswidener
+++ b/BAMO_BSMP/src/main/resources/bamo.accesswidener
@@ -1,0 +1,2 @@
+accessWidener v2 named
+accessible field net/minecraft/resource/ResourcePackManager providers Ljava/util/Set;

--- a/BAMO_BSMP/src/main/resources/fabric.mod.json
+++ b/BAMO_BSMP/src/main/resources/fabric.mod.json
@@ -30,6 +30,7 @@
     ]
   },
   "mixins": [],
+  "accessWidener": "bamo.accesswidener",
   "depends": {
     "fabricloader": ">=0.8.7",
     "fabric": "*",


### PR DESCRIPTION
Updated both `PackFinder` classes and `MergedResourcePack` for 1.20.1
This required the addition of an AccessWidener due to Fabric changing `ResourcePackManagerAccessor` to a general mixin.